### PR TITLE
fix: restaurar función en pruebas de tareas

### DIFF
--- a/tests/test_identificador_tarea.py
+++ b/tests/test_identificador_tarea.py
@@ -316,14 +316,19 @@ def test_identificador_tarea_duplicada(tmp_path):
     email_utils.procesar_correo_a_tarea = wrap
     mod.procesar_correo_a_tarea = wrap
 
-    with bd.SessionLocal() as s:
-        prev = s.query(bd.TareaProgramada).count()
+    total = None
+    try:
+        with bd.SessionLocal() as s:
+            prev = s.query(bd.TareaProgramada).count()
 
-    asyncio.run(mod.procesar_identificador_tarea(update, ctx))
-    asyncio.run(mod.procesar_identificador_tarea(update, ctx))
+        asyncio.run(mod.procesar_identificador_tarea(update, ctx))
+        asyncio.run(mod.procesar_identificador_tarea(update, ctx))
 
-    with bd.SessionLocal() as s:
-        total = s.query(bd.TareaProgramada).count()
+        with bd.SessionLocal() as s:
+            total = s.query(bd.TareaProgramada).count()
+    finally:
+        email_utils.procesar_correo_a_tarea = real_proc
+        mod.procesar_correo_a_tarea = real_proc
 
     tempfile.gettempdir = orig_tmp
 


### PR DESCRIPTION
## Summary
- repone procesar_correo_a_tarea luego de ejecutar el test de duplicados

## Testing
- `bash setup_env.sh`
- `pytest -q` *(falla: AttributeError en pandas)*

------
https://chatgpt.com/codex/tasks/task_e_6850b0bc4ed08330aa34586d2373b81f