### PR TITLE
Cambiar cierre de sesiones en test_listar_tareas

### DIFF
--- a/tests/test_listar_tareas.py
+++ b/tests/test_listar_tareas.py
@@ -58,6 +58,9 @@ import sandybot.database as bd
 
 sqlalchemy.create_engine = orig_engine
 bd.SessionLocal = sessionmaker(bind=bd.engine, expire_on_commit=False)
+# Compatibilidad con SQLAlchemy 2.0
+from sqlalchemy.orm import close_all_sessions
+bd.SessionLocal.close_all_sessions = close_all_sessions
 bd.Base.metadata.create_all(bind=bd.engine)
 
 
@@ -71,10 +74,12 @@ def reiniciar_bd():
     engine = sqlalchemy.create_engine("sqlite:///:memory:")
     bd.engine = engine
     bd.SessionLocal = sessionmaker(bind=engine, expire_on_commit=False)
+    from sqlalchemy.orm import close_all_sessions
+    bd.SessionLocal.close_all_sessions = close_all_sessions
     bd.Base.metadata.create_all(bind=engine)
     yield
     bd.Base.metadata.drop_all(bind=engine)
-    bd.SessionLocal.close_all()
+    bd.SessionLocal.close_all_sessions()
     engine.dispose()
     bd.engine = old_engine
     bd.SessionLocal = old_session


### PR DESCRIPTION
## Summary
- actualizar el método de cierre de sesiones en test_listar_tareas
- crear compatibilidad con SQLAlchemy 2.0

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850b16b78d48330b6c903cdee931a17