### PR TITLE
Update dev deps and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -448,8 +448,10 @@ pip install -r "Sandy bot/requirements.txt"
 ```
 Antes de lanzar `pytest` para evitar errores de importación.
 
-Algunas pruebas relacionadas con la base de datos se omiten de forma automática si `SQLAlchemy`
-no está presente en el entorno.
+
+Algunas pruebas relacionadas con la base de datos se omiten de forma automática si `SQLAlchemy` no está presente en el entorno.
+
+En `requirements-dev.txt` se establecen las versiones mínimas de `pytest` y `pytest-cov`. Si la suite de pruebas cambia o se amplía, recordá actualizar estos valores para evitar incompatibilidades.
 
 
 ## Licencia

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,2 @@
-pytest
-pytest-cov
+pytest>=7.0
+pytest-cov>=4.0


### PR DESCRIPTION
## Summary
- set minimum versions for pytest tools
- document dev dependency updates in README

## Testing
- `bash setup_env.sh`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'six.moves')*

------
https://chatgpt.com/codex/tasks/task_e_685156ef1ad4833099ec404c4cce47af