### PR TITLE
feat: optimizar calculo de diferencias

### DIFF
--- a/Sandy bot/sandybot/database.py
+++ b/Sandy bot/sandybot/database.py
@@ -583,6 +583,13 @@ def actualizar_tracking(
                     existentes = []
 
             nuevos = []
+            if camaras is not None:
+                # Se calcula una sola vez para evitar repetir este proceso
+                nuevas = {normalizar_camara(c) for c in camaras}
+                anteriores = {normalizar_camara(c) for c in cam_anterior}
+                dif_agregadas = nuevas - anteriores
+                dif_quitadas = anteriores - nuevas
+
             for t in trackings_txt:
                 if isinstance(t, dict):
                     entrada = t
@@ -593,10 +600,6 @@ def actualizar_tracking(
                         "fecha": datetime.utcnow().isoformat(),
                     }
                 if camaras is not None:
-                    nuevas = {normalizar_camara(c) for c in camaras}
-                    anteriores = {normalizar_camara(c) for c in cam_anterior}
-                    dif_agregadas = nuevas - anteriores
-                    dif_quitadas = anteriores - nuevas
                     entrada["nuevas"] = [
                         c for c in camaras if normalizar_camara(c) in dif_agregadas
                     ]


### PR DESCRIPTION
## Summary
- mejora `actualizar_tracking` para calcular una sola vez las cámaras nuevas, anteriores y diferencias

## Testing
- `pytest -q` *(fails: ImportError: cannot import name 'procesar_correo_a_tarea')*


------
https://chatgpt.com/codex/tasks/task_e_68518a98a4a4833094dd27c6a3eb0449