### PR TITLE
Implementar marca de cache sucia en GPTHandler

### DIFF
--- a/Sandy bot/sandybot/config.py
+++ b/Sandy bot/sandybot/config.py
@@ -100,6 +100,8 @@ class Config:  # pylint: disable=too-many-instance-attributes
         self.GPT_TIMEOUT = 30
         self.GPT_MAX_RETRIES = 3
         self.GPT_CACHE_TIMEOUT = 3600  # 1 hora
+        # Cada cuántas consultas se persiste la cache de GPT
+        self.GPT_CACHE_SAVE_INTERVAL = int(os.getenv("GPT_CACHE_SAVE_INTERVAL", "5"))
 
         # 8) Conexión BD
         self.DB_HOST = os.getenv("DB_HOST", "localhost")

--- a/tests/test_gpt_cache.py
+++ b/tests/test_gpt_cache.py
@@ -67,6 +67,8 @@ config_mod = importlib.import_module("sandybot.config")
 def test_persistencia_cache(tmp_path):
     cache_file = tmp_path / "gpt_cache.json"
     config_mod.config.GPT_CACHE_FILE = cache_file
+    # Forzar guardado en disco tras cada consulta
+    config_mod.config.GPT_CACHE_SAVE_INTERVAL = 1
 
     gpt_module = importlib.reload(importlib.import_module("sandybot.gpt_handler"))
     handler = gpt_module.GPTHandler()


### PR DESCRIPTION
## Summary
- añadir flag `_dirty` y contador en `GPTHandler`
- guardar la cache solo cada cierto número de consultas
- registrar guardado al salir
- exponer intervalo configurable en `Config`
- actualizar prueba de cache

## Testing
- `pytest tests/test_gpt_cache.py -q`
- `pytest -q` *(fallos por dependencias)*

------
https://chatgpt.com/codex/tasks/task_e_68518aafdbc483308359607278773316