### PR TITLE
feat: horas netas con decimales

### DIFF
--- a/Sandy bot/sandybot/handlers/informe_sla.py
+++ b/Sandy bot/sandybot/handlers/informe_sla.py
@@ -408,7 +408,7 @@ def _generar_documento_sla(
         return f"{h:03d}:{m:02d}:{s:02d}"
 
     def _horas_decimal(val) -> str:
-        """Convierte valores de horas a un número entero de horas."""
+        """Devuelve las horas en formato decimal con dos digitos."""
         if pd.isna(val) or val == "":
             return ""
         s = str(val).lower().replace(",", ".")
@@ -416,12 +416,13 @@ def _generar_documento_sla(
         s = s.replace("horas", "hours").replace("hora", "hours")
         try:
             td = pd.to_timedelta(s)
-            return str(int(td.total_seconds() // 3600))
+            horas = td.total_seconds() / 3600
         except Exception:
             try:
-                return str(int(float(s)))
+                horas = float(s)
             except Exception:
                 return s
+        return f"{horas:.2f}"
 
     meses = ["ene", "feb", "mar", "abr", "may", "jun", "jul", "ago", "sep", "oct", "nov", "dic"]
 
@@ -566,7 +567,7 @@ def _generar_documento_sla(
         fila_tot = t3.add_row().cells
         fila_tot[0].text = "Total"
         if total_h:
-            fila_tot[2].text = str(int(total_h))
+            fila_tot[2].text = f"{total_h:.2f}"
 
         # Salto de página entre servicios
         if idx_srv < total_servicios - 1:

--- a/tests/test_informe_sla.py
+++ b/tests/test_informe_sla.py
@@ -340,6 +340,8 @@ def test_bloque_con_parrafos(tmp_path):
     entre = [child for child in body[idx2 + 1:idx3] if child.tag.endswith("p")]
     from docx.text.paragraph import Paragraph
     assert any("Eventos" in Paragraph(p, doc).text for p in entre)
+    tabla3 = doc.tables[-1]
+    assert tabla3.rows[1].cells[2].text == "0.00"
 
 
 def test_generar_con_ticket(tmp_path):
@@ -365,6 +367,7 @@ def test_generar_con_ticket(tmp_path):
     doc = Document(doc_path)
     tabla3 = doc.tables[-1]
     assert tabla3.rows[1].cells[1].text == "1"
+    assert tabla3.rows[1].cells[2].text == "0.00"
 
 
 def test_tabla2_completa(tmp_path):


### PR DESCRIPTION
## Summary
- mostrar las horas netas de reclamos con dos decimales en el .doc
- probar la nueva lógica en las pruebas unitarias

## Testing
- `pytest tests/test_informe_sla.py -q`
- `pytest -q` *(falla: ImportError por dependencias faltantes)*

------
https://chatgpt.com/codex/tasks/task_e_685431027a888330b3edf3031a3c936d