### PR TITLE
Añadir mapas en informe de repetitividad

### DIFF
--- a/Sandy bot/requirements.txt
+++ b/Sandy bot/requirements.txt
@@ -15,4 +15,8 @@ jsonschema>=4.0.0
 SQLAlchemy>=1.4
 textract==1.6.3  # opcional para archivos .doc
 beautifulsoup4>=4.8.0,<5
+geopandas>=1.0
+contextily>=1.6
+shapely>=2.0
+matplotlib>=3.8
 

--- a/Sandy bot/sandybot/geo_utils.py
+++ b/Sandy bot/sandybot/geo_utils.py
@@ -1,0 +1,66 @@
+# Nombre de archivo: geo_utils.py
+# Ubicación de archivo: Sandy bot/sandybot/geo_utils.py
+# User-provided custom instructions
+"""Funciones para trabajar con coordenadas geográficas."""
+
+from __future__ import annotations
+
+import re
+from typing import Iterable
+
+import geopandas as gpd
+import contextily as ctx
+from shapely.geometry import Point
+import matplotlib.pyplot as plt
+
+
+def extraer_coordenada(texto: str) -> tuple[float, float] | None:
+    """Obtiene la primera coordenada válida dentro de ``texto``."""
+    if not texto:
+        return None
+    limpio = re.sub(r"(?i)geo[:\s]*", "", texto)
+    limpio = limpio.replace("--", "-")
+    patron = re.compile(r"(-?\d+(?:\.\d+)?)[,\s]+(-?\d+(?:\.\d+)?)")
+    m = patron.search(limpio)
+    if not m:
+        return None
+    lat, lon = m.groups()
+    lat = lat.strip()
+    lon = lon.strip()
+    if re.match(r"^34", lat):
+        lat = "-" + lat
+    if re.match(r"^58", lon):
+        lon = "-" + lon
+    if not re.match(r"^-34", lat) or not re.match(r"^-58", lon):
+        return None
+    try:
+        return float(lat), float(lon)
+    except ValueError:
+        return None
+
+
+def generar_mapa_puntos(puntos: Iterable[tuple[float, float]], linea: str, ruta: str) -> None:
+    """Genera un mapa PNG con ``puntos`` etiquetados por ``linea``."""
+    gdf = gpd.GeoDataFrame(
+        index=range(len(list(puntos))),
+        geometry=[Point(lon, lat) for lat, lon in puntos],
+        crs="EPSG:4326",
+    )
+    gdf3857 = gdf.to_crs(epsg=3857)
+    ax = gdf3857.plot(figsize=(6, 6), color="red")
+    for x, y in zip(gdf3857.geometry.x, gdf3857.geometry.y):
+        ax.text(
+            x,
+            y,
+            linea,
+            ha="center",
+            va="center",
+            color="white",
+            fontsize=8,
+            bbox=dict(boxstyle="circle", facecolor="blue"),
+        )
+    ctx.add_basemap(ax, crs="EPSG:3857", source=ctx.providers.OpenStreetMap.Mapnik)
+    ax.set_axis_off()
+    plt.tight_layout()
+    plt.savefig(ruta, dpi=150)
+    plt.close()

--- a/Sandy bot/sandybot/handlers/repetitividad.py
+++ b/Sandy bot/sandybot/handlers/repetitividad.py
@@ -10,6 +10,8 @@ import os
 import tempfile
 import pandas as pd
 from docx import Document
+from docx.enum.text import WD_PARAGRAPH_ALIGNMENT
+from docx.shared import Inches
 # Los siguientes módulos solo están disponibles en Windows. Se usan para
 # modificar el documento Word mediante COM.
 try:
@@ -28,6 +30,7 @@ from sandybot.config import config
 from ..utils import obtener_mensaje
 from .estado import UserState
 from ..registrador import responder_registrando, registrar_conversacion
+from ..geo_utils import extraer_coordenada, generar_mapa_puntos
 
 # Ruta a la plantilla Word definida en la configuración global
 # Permite modificar la ubicación mediante la variable de entorno "PLANTILLA_PATH"
@@ -261,6 +264,8 @@ Configurá la variable PLANTILLA_PATH."
         hdr_cells[5].text = 'Horas Netas Problema Reclamo'
         hdr_cells[6].text = 'Descripción Solución Reclamo'
 
+        coordenadas = []
+
         for _, fila in grupo.iterrows():
             fila_cells = tabla.add_row().cells
             fila_cells[0].text = str(fila['Número Reclamo'])
@@ -293,6 +298,18 @@ Configurá la variable PLANTILLA_PATH."
                 fila_cells[5].text = ''
 
             fila_cells[6].text = fila['Descripción Solución Reclamo']
+            coord = extraer_coordenada(fila['Descripción Solución Reclamo'])
+            if coord:
+                coordenadas.append(coord)
+
+        if coordenadas:
+            imagen = os.path.join(tempfile.gettempdir(), f"mapa_linea_{numero_linea}.png")
+            generar_mapa_puntos(coordenadas, str(numero_linea), imagen)
+            parrafo_mapa = tabla._element.getparent().add_paragraph()
+            run = parrafo_mapa.add_run()
+            run.add_picture(imagen, width=Inches(5))
+            parrafo_mapa.alignment = WD_PARAGRAPH_ALIGNMENT.CENTER
+            os.remove(imagen)
 
     nombre_archivo = f"InformeRepetitividad{fecha_cierre.strftime('%m%y')}.docx"
     ruta_docx_generado = os.path.join(tempfile.gettempdir(), nombre_archivo)


### PR DESCRIPTION
## Resumen
- crear modulo `geo_utils` para extraer coordenadas y generar mapas
- insertar mapas debajo de la tabla 3 usando `geo_utils`
- agregar dependencias geográficas

## Testing
- `pytest -q` *(fallan varias pruebas)*

------
https://chatgpt.com/codex/tasks/task_e_6859a52f18f483308e9fa9400a29a971